### PR TITLE
Update upstream

### DIFF
--- a/docs/api/in-app-purchase.md
+++ b/docs/api/in-app-purchase.md
@@ -25,8 +25,10 @@ The `inAppPurchase` module has the following methods:
 
 * `productID` String - The id of the product to purchase. (the id of `com.example.app.product1` is `product1`).
 * `quantity` Integer (optional) - The number of items the user wants to purchase.
-* `callback` Function (optional) - The callback called when the payment is added to the PaymentQueue. (You should add a listener with `inAppPurchase.addTransactionsListener` to get the transaction status).
-  * `isProductValid` Boolean - Determine if the product is valid and added to the payment queue.
+* `callback` Function (optional) - The callback called when the payment is added to the PaymentQueue.
+* `isProductValid` Boolean - Determine if the product is valid and added to the payment queue.
+
+You should listen for the `transactions-updated` event as soon as possible and certainly before you call `purchaseProduct`.
 
 ### `inAppPurchase.canMakePayments()`
 


### PR DESCRIPTION
* Update inAppPurchase API doc

`addTransactionsListener` is no longer supported. Users have to listen for the `transactions-updated` event instead.

* Tweak `transactions-updated` timing description

Make the documentation edit suggested by @felixrieseberg and thumbs-upped by @AdrienFery

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->