### PR TITLE
Update upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@
 node_modules/
 SHASUMS256.txt
 **/package-lock.json
+**/yarn.lock
+
+# npm package
+/npm/dist
+/npm/path.txt

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -85,3 +85,13 @@ This environment variable will not work if the `crashReporter` is started.
 Shows the Windows's crash dialog when Electron crashes.
 
 This environment variable will not work if the `crashReporter` is started.
+
+### `ELECTRON_OVERRIDE_DIST_PATH`
+
+When running from the `electron` package, this variable tells
+the `electron` command to use the specified build of Electron instead of
+the one downloaded by `npm install`. Usage:
+
+```sh
+export ELECTRON_OVERRIDE_DIST_PATH=/Users/username/projects/electron/out/D
+```

--- a/npm/index.js
+++ b/npm/index.js
@@ -3,8 +3,16 @@ var path = require('path')
 
 var pathFile = path.join(__dirname, 'path.txt')
 
-if (fs.existsSync(pathFile)) {
-  module.exports = path.join(__dirname, fs.readFileSync(pathFile, 'utf-8'))
-} else {
-  throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again')
+function getElectronPath () {
+  if (fs.existsSync(pathFile)) {
+    var executablePath = fs.readFileSync(pathFile, 'utf-8')
+    if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
+      return path.join(process.env.ELECTRON_OVERRIDE_DIST_PATH, executablePath)
+    }
+    return path.join(__dirname, 'dist', executablePath)
+  } else {
+    throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again')
+  }
 }
+
+module.exports = getElectronPath()

--- a/npm/install.js
+++ b/npm/install.js
@@ -52,12 +52,12 @@ function getPlatformPath () {
 
   switch (platform) {
     case 'darwin':
-      return 'dist/Electron.app/Contents/MacOS/Electron'
+      return 'Electron.app/Contents/MacOS/Electron'
     case 'freebsd':
     case 'linux':
-      return 'dist/electron'
+      return 'electron'
     case 'win32':
-      return 'dist/electron.exe'
+      return 'electron.exe'
     default:
       throw new Error('Electron builds are not available on platform: ' + platform)
   }


### PR DESCRIPTION
* Provide an easy way to use a local build of Electron

For instance from ~/projects/electron/out/D

* document ELECTRON_OVERRIDE_DIST_PATH

* Make the linter happy

* Tweak ELECTRON_OVERRIDE_DIST_PATH docs

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/electron/electron/blob/master/CONTRIBUTING.md
-->