### PR TITLE
Create a new pull request by comparing changes across two branches

### DIFF
--- a/shell/browser/electron_browser_context.h
+++ b/shell/browser/electron_browser_context.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -80,41 +81,22 @@ class ElectronBrowserContext : public content::BrowserContext {
 
   // partition_id => browser_context
   struct PartitionKey {
-    enum class KeyType { Partition, FilePath };
-    std::string location;
-    bool in_memory;
-    KeyType partition_type;
+    PartitionKey(const std::string_view partition, bool in_memory)
+        : type_{Type::Partition}, location_{partition}, in_memory_{in_memory} {}
 
-    PartitionKey(const std::string& partition, bool in_memory)
-        : location(partition),
-          in_memory(in_memory),
-          partition_type(KeyType::Partition) {}
     explicit PartitionKey(const base::FilePath& file_path)
-        : location(file_path.AsUTF8Unsafe()),
-          in_memory(false),
-          partition_type(KeyType::FilePath) {}
+        : type_{Type::Path},
+          location_{file_path.AsUTF8Unsafe()},
+          in_memory_{false} {}
 
-    bool operator<(const PartitionKey& other) const {
-      if (partition_type == KeyType::Partition) {
-        if (location == other.location)
-          return in_memory < other.in_memory;
-        return location < other.location;
-      } else {
-        if (location == other.location)
-          return false;
-        return location < other.location;
-      }
-    }
+    friend auto operator<=>(const PartitionKey&, const PartitionKey&) = default;
 
-    bool operator==(const PartitionKey& other) const {
-      if (partition_type == KeyType::Partition) {
-        return (location == other.location) && (in_memory < other.in_memory);
-      } else {
-        if (location == other.location)
-          return true;
-        return false;
-      }
-    }
+   private:
+    enum class Type { Partition, Path };
+
+    Type type_;
+    std::string location_;
+    bool in_memory_;
   };
 
   using BrowserContextMap =


### PR DESCRIPTION
* fix: ElectronBrowserContext::PartitionKey comparisons

Use c++20 default comparisons to simplify + fix PartitionKey sorting:

- The equality operator is broken. `PartitionKey{"foo", false}` is both equal, to and less than, `PartitionKey{"foo", true}`

- For some keys, the same session can be retrieved via both `fromPath()` and `fromPartition()`. This use case was discussed and removed from the original PR after code review said "always returning different sessions feels lower maintenance." The current behavior is a bug that comes from the comparison operators not checking the keys' types.

Xref: https://github.com/electron/electron/pull/36728/commits/3f1aea9af91e17b2605eb8a5837bbb81888d76da#r1099745359

Xref: https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++-features.md#Default-comparisons-allowed

* fixup! fix: ElectronBrowserContext::PartitionKey comparisons

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
