### PR TITLE
Create a new pull request by comparing changes across two branches

### DIFF
--- a/docs/api/web-contents-view.md
+++ b/docs/api/web-contents-view.md
@@ -36,8 +36,9 @@ Process: [Main](../glossary.md#main-process)
 
 * `options` Object (optional)
   * `webPreferences` [WebPreferences](structures/web-preferences.md) (optional) - Settings of web page's features.
+  * `webContents` [WebContents](web-contents.md) (optional) - If present, the given WebContents will be adopted by the WebContentsView. A WebContents may only be presented in one WebContentsView at a time.
 
-Creates an empty WebContentsView.
+Creates a WebContentsView.
 
 ### Instance Properties
 

--- a/shell/browser/api/electron_api_web_contents_view.cc
+++ b/shell/browser/api/electron_api_web_contents_view.cc
@@ -138,6 +138,7 @@ v8::Local<v8::Function> WebContentsView::GetConstructor(v8::Isolate* isolate) {
 // static
 gin_helper::WrappableBase* WebContentsView::New(gin_helper::Arguments* args) {
   gin_helper::Dictionary web_preferences;
+  v8::Local<v8::Value> existing_web_contents_value;
   {
     v8::Local<v8::Value> options_value;
     if (args->GetNext(&options_value)) {
@@ -154,12 +155,33 @@ gin_helper::WrappableBase* WebContentsView::New(gin_helper::Arguments* args) {
           return nullptr;
         }
       }
+
+      if (options.Get("webContents", &existing_web_contents_value)) {
+        gin::Handle<WebContents> existing_web_contents;
+        if (!gin::ConvertFromV8(args->isolate(), existing_web_contents_value,
+                                &existing_web_contents)) {
+          args->ThrowError("options.webContents must be a WebContents");
+          return nullptr;
+        }
+
+        if (existing_web_contents->owner_window() != nullptr) {
+          args->ThrowError(
+              "options.webContents is already attached to a window");
+          return nullptr;
+        }
+      }
     }
   }
+
   if (web_preferences.IsEmpty())
     web_preferences = gin_helper::Dictionary::CreateEmpty(args->isolate());
   if (!web_preferences.Has(options::kShow))
     web_preferences.Set(options::kShow, false);
+
+  if (!existing_web_contents_value.IsEmpty()) {
+    web_preferences.SetHidden("webContents", existing_web_contents_value);
+  }
+
   auto web_contents =
       WebContents::CreateFromWebPreferences(args->isolate(), web_preferences);
 


### PR DESCRIPTION
feat: Allow WebContentsView to accept webContents object

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
